### PR TITLE
JuliaDB -> DataFrames

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,11 +3,13 @@ uuid = "ac199af8-68bc-55b8-82c4-7abd6f96ed98"
 version = "0.2.0"
 
 [deps]
+CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
-JuliaDB = "a93385a2-3734-596a-9a66-3cfbb77141e6"
 
 [compat]
-JuliaDB = "^0.12"
+CSV = "0.8"
+DataFrames = "^0.21"
 julia = "^1.0.0"
 
 [extras]

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ julia> ssmc_matrices("", "bcsstk")    # all matrices whose name contains "bcsstk
 julia> ssmc_matrices("HB", "")        # all matrices whose group contains "HB"
 
 julia> # select symmetric positive definite matrices with ≤ 100 rows and columns
-julia> tiny = filter(p -> p.structure == "symmetric" && p.posDef == "yes" && p.type == "real" && p.rows ≤ 100, ssmc)
+julia> tiny = ssmc[(ssmc.structure .== "symmetric") .& (ssmc.posDef .== "yes") .& (ssmc.type .== "real") .& (ssmc.rows .≤ 100), :]
 
 julia> # fetch the matrices selects in MatrixMarket format
 julia> fetch_ssmc(tiny, format="MM")
@@ -41,24 +41,23 @@ Matrices are available in formats:
 * `"mat"`: Matlab's [MAT-file format](https://www.mathworks.com/help/pdf_doc/matlab/matfile_format.pdf);
 * `"MM"`: the [MatrixMarket format](http://math.nist.gov/MatrixMarket/formats.html#MMformat).
 
-If `JuliaDB` is explicitly installed, it is possible to further examine a list of selected matrices:
+Use `DataFrames` syntax to further examine a list of selected matrices:
 ```julia
-julia> using JuliaDB
-
-julia> select(tiny, (:name, :rows, :cols, :posDef, :kind))
-Table with 10 rows, 5 columns:
-name        rows  cols  posDef  kind
-──────────────────────────────────────────────────────────────────────
-"bcsstk01"  48    48    "yes"   "structural problem"
-"bcsstk02"  66    66    "yes"   "structural problem"
-"bcsstm02"  66    66    "yes"   "structural problem"
-"nos4"      100   100   "yes"   "structural problem"
-"ex5"       27    27    "yes"   "computational fluid dynamics problem"
-"mesh1e1"   48    48    "yes"   "structural problem"
-"mesh1em1"  48    48    "yes"   "structural problem"
-"mesh1em6"  48    48    "yes"   "structural problem"
-"LF10"      18    18    "yes"   "model reduction problem"
-"LFAT5"     14    14    "yes"   "model reduction problem"
+julia> tiny[!, [:name, :rows, :cols, :posDef, :kind])
+10×5 DataFrames.DataFrame
+│ Row │ name     │ rows  │ cols  │ posDef │ kind                                 │
+│     │ String   │ Int64 │ Int64 │ String │ String                               │
+├─────┼──────────┼───────┼───────┼────────┼──────────────────────────────────────┤
+│ 1   │ bcsstk01 │ 48    │ 48    │ yes    │ structural problem                   │
+│ 2   │ bcsstk02 │ 66    │ 66    │ yes    │ structural problem                   │
+│ 3   │ bcsstm02 │ 66    │ 66    │ yes    │ structural problem                   │
+│ 4   │ nos4     │ 100   │ 100   │ yes    │ structural problem                   │
+│ 5   │ ex5      │ 27    │ 27    │ yes    │ computational fluid dynamics problem │
+│ 6   │ mesh1e1  │ 48    │ 48    │ yes    │ structural problem                   │
+│ 7   │ mesh1em1 │ 48    │ 48    │ yes    │ structural problem                   │
+│ 8   │ mesh1em6 │ 48    │ 48    │ yes    │ structural problem                   │
+│ 9   │ LF10     │ 18    │ 18    │ yes    │ model reduction problem              │
+│ 10  │ LFAT5    │ 14    │ 14    │ yes    │ model reduction problem              │
 ```
 
 Matrices in Rutherford-Boeing format can be opened with [`HarwellRutherfordBoeing.jl`](https://github.com/JuliaSparse/HarwellRutherfordBoeing.jl):

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,7 +1,9 @@
 [deps]
+CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-JuliaDB = "a93385a2-3734-596a-9a66-3cfbb77141e6"
 
 [compat]
+CSV = "0.8"
+DataFrames = "^0.21"
 Documenter = "~0.25"
-JuliaDB = "^0.12"

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -15,8 +15,8 @@ ssmc_formats
 ## Utilities
 
 ```@docs
-group_path
-matrix_path
+group_paths
+matrix_paths
 ssmc_matrices
 fetch_ssmc
 ```

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,14 +4,14 @@ using Test
 
 function test_fetch()
   two_square = filter(p -> p.structure == "symmetric" && p.posDef == "no" && p.type == "real" && p.rows ≤ 100, ssmc)
-  @test length(two_square) == 2
+  @test size(two_square, 1) == 2
   for format in SuiteSparseMatrixCollection.ssmc_formats
     Sys.iswindows() && format != "mat" && continue
     fetch_ssmc(two_square, format=format)
-    for matrix in two_square
-      g_path = group_path(matrix, format=format)
+    g_paths = group_paths(two_square, format=format)
+    mtx_paths = matrix_paths(two_square, format=format)
+    for (matrix, g_path, mtx_path) in zip(eachrow(two_square), g_paths, mtx_paths)
       @test isdir(g_path)
-      mtx_path = matrix_path(matrix, format=format)
       ext = format == "mat" ? "mat" : (format == "MM" ? "mtx" : "rb")
       if ext == "mat"
         @test isfile(joinpath(g_path, "$(matrix.name).$(ext)"))
@@ -25,24 +25,25 @@ end
 
 function test_select()
   bcsstk = ssmc_matrices("", "bcsstk")
-  @test length(bcsstk) == 39
+  @test size(bcsstk, 1) == 39
 
-  bcsstk_small = filter(p -> p.rows ≤ 100, bcsstk)
-  @test length(bcsstk_small) == 2
+  bcsstk_small = bcsstk[bcsstk.rows .≤ 100, :]
+  @test size(bcsstk_small, 1) == 2
 
   hb_bcsstk = ssmc_matrices("HB", "bcsstk")
-  @test length(hb_bcsstk) == 33
+  @test size(hb_bcsstk, 1) == 33
 
   hb_matrices = ssmc_matrices("HB", "")
-  @test length(hb_matrices) == 292
+  @test size(hb_matrices, 1) == 292
 end
 
 function test_fetch_by_name()
-  arenas = ssmc_matrices("Arenas", "")
-  @test length(arenas) == 4
-  fetch_ssmc("Arenas", "", format="mat")
-  for matrix in arenas
-    g_path = group_path(matrix, format="mat")
+  subset = ssmc_matrices("Belcastro", "")
+  @test size(subset, 1) == 3
+  fetch_ssmc("Belcastro", "", format="mat")
+  g_paths = group_paths(subset, format="mat")
+  mtx_paths = matrix_paths(subset, format = "mat")
+  for (matrix, g_path, mtx_path) in zip(eachrow(subset), g_paths, mtx_paths)
     @test isdir(g_path)
     @test isfile(joinpath(g_path, "$(matrix.name).mat"))
   end


### PR DESCRIPTION
Read the database with CSV and provide a DataFrame view.
This allows using the familiar DataFrame syntax to sift through the
dataset. However, CSV doesn't appear to consider the same rows of the
database as valid, so some matrices that used to be available are no
longer available (e.g., the Arenas matrices). Thus, this is a breaking
update.

Main differences:
* the database is read with CSV and a DataFrame "view" is provided;
* a selection of matrices always returns a DataFrame or a DataFrameRow;
* group_path and matrix_path become group_paths and matrix_paths because
  those methods always return an array of paths.