### PR TITLE
Release 0.5.4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SuiteSparseMatrixCollection"
 uuid = "ac199af8-68bc-55b8-82c4-7abd6f96ed98"
-version = "0.5.3"
+version = "0.5.4"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
@@ -8,7 +8,7 @@ JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [compat]
-DataFrames = "0.21, 0.22, 1"
+DataFrames = "0.21 - 1.3"
 JLD2 = "0.3, 0.4"
 julia = "1.6.2, 1"
 


### PR DESCRIPTION
Our current `ssmc.jld2` is not compatible with DataFrames v1.4.
#63 