### PR TITLE
Depend on Artifacts directly instead of via Pkg

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,16 +3,16 @@ uuid = "ac199af8-68bc-55b8-82c4-7abd6f96ed98"
 version = "0.5.7"
 
 [deps]
+Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
 [compat]
+Artifacts = "1.6"
 DataFrames = "1.4"
 JLD2 = "0.5"
-Pkg = "1.6"
 Printf = "1.6"
 REPL = "1.6"
 Test = "1.6"

--- a/src/SuiteSparseMatrixCollection.jl
+++ b/src/SuiteSparseMatrixCollection.jl
@@ -1,6 +1,6 @@
 module SuiteSparseMatrixCollection
 
-using Pkg.Artifacts
+using Artifacts
 
 using DataFrames
 using JLD2


### PR DESCRIPTION
- Pkg depends on artifacts so this lightens the dependency chain slightly
- Pkg.Artifacts is actually a slightly hacked and modified version of Artifacts, with this change SuiteSparseMatrixCollection.jl will depend on the canonical version of Artifacts so upstream bugs should be less common and easier to report 

(I found this from JuliaLang/julia#58276)